### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/corps/affiche.php
+++ b/corps/affiche.php
@@ -388,7 +388,7 @@ if (!empty($id_sql)) {
 			print"<td><strong>".SOLVANT."</strong>&nbsp;".$solvant."</td>
 				  </tr>
 				  <tr><td><strong>".DOI."</strong>&nbsp;";
-			if (!empty($row2[18])) print"<a href=\"http://dx.doi.org/".$row2[18]."\" target=\"_blank\">".$row2[18]."</a>";
+			if (!empty($row2[18])) print"<a href=\"https://doi.org/".$row2[18]."\" target=\"_blank\">".$row2[18]."</a>";
 			print"</td><td><strong>".CAS."</strong>&nbsp;".$row2[19]."</td><td><strong>".HAL."</strong>&nbsp;";
 			if (!empty($row2[20])) print"<a href=\"http://hal.archives-ouvertes.fr/".$row2[20]."/fr/\" target=\"_blank\">".$row2[20]."</a>";
 

--- a/corps/afficherecherche.php
+++ b/corps/afficherecherche.php
@@ -366,7 +366,7 @@ if (!empty($id_sql)) {
 		print"<td><strong>".SOLVANT."</strong>&nbsp;".$solvant."</td>
 		  </tr>
 		  <tr><td><strong>".DOI."</strong>&nbsp;";
-		if (!empty($row2[19])) print"<a href=\"http://dx.doi.org/".$row2[19]."\" target=\"_blank\">".$row2[19]."</a>";
+		if (!empty($row2[19])) print"<a href=\"https://doi.org/".$row2[19]."\" target=\"_blank\">".$row2[19]."</a>";
 		print"</td><td><strong>".CAS."</strong>&nbsp;".$row2[20]."</td><td><strong>".HAL."</strong>&nbsp;";
 		if (!empty($row2[21])) print"<a href=\"http://hal.archives-ouvertes.fr/".$row2[21]."/fr/\" target=\"_blank\">".$row2[21]."</a>";
 			print"</td></tr>


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update the code that generates new DOI links.

Cheers!